### PR TITLE
Minor fixes for documentation generators and a job to publish the latest docs with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,10 @@ script:
 after_success:
     - coveralls
     - cd docs && make
-    
+
+before_deploy:
+    - touch docs/build/html/.nojekyll
+
 deploy:
   provider: pages
   cleanup: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,3 +51,12 @@ script:
 after_success:
     - coveralls
     - cd docs && make
+    
+deploy:
+  provider: pages
+  cleanup: false
+  token: $TRAVIS_DEPLOY
+  keep_history: true
+  local_dir: docs/build/html
+  on:
+    branch: master

--- a/docs/ext/docscrape.py
+++ b/docs/ext/docscrape.py
@@ -114,7 +114,7 @@ class NumpyDocString(object):
         return self._parsed_data[key]
 
     def __setitem__(self,key,val):
-        if not self._parsed_data.has_key(key):
+        if key not in self._parsed_data:
             warn("Unknown section %s" % key)
         else:
             self._parsed_data[key] = val
@@ -449,7 +449,7 @@ class FunctionDoc(NumpyDocString):
                  'meth': 'method'}
 
         if self._role:
-            if not roles.has_key(self._role):
+            if self._role not in roles:
                 print("Warning: invalid role %s" % self._role)
             out += '.. %s:: %s\n    \n\n' % (roles.get(self._role,''),
                                              func_name)

--- a/docs/ext/numpydoc.py
+++ b/docs/ext/numpydoc.py
@@ -33,7 +33,7 @@ def mangle_docstrings(app, what, name, obj, options, lines,
         lines[:] = title_re.sub(u'', u"\n".join(lines)).split(u"\n")
     else:
         doc = get_doc_object(obj, what, u"\n".join(lines), config=cfg)
-        lines[:] = doc.split(u"\n")
+        lines[:] = str(doc).split(u"\n")
 
     if app.config.numpydoc_edit_link and hasattr(obj, '__name__') and \
            obj.__name__:

--- a/docs/source/index.txt
+++ b/docs/source/index.txt
@@ -30,7 +30,7 @@ Sections
 
        Introduction to skfuzzy.
 
-     - `API Reference <api/api.html>`_
+     - `API Reference <api/index.html>`_
 
        Documentation for the functions included in skfuzzy.
 

--- a/docs/source/userguide/getting_started.txt
+++ b/docs/source/userguide/getting_started.txt
@@ -22,7 +22,7 @@ Finding your way around
 -----------------------
 
 A list of submodules and functions is found on the `API reference
-<../api/api.html>`_ webpage.
+<../api/index.html>`_ webpage.
 
 Within :mod:`scikit-fuzzy`, universe variables and fuzzy membership functions are
 represented by :mod:`numpy` arrays. Generation of membership functions is


### PR DESCRIPTION
Hi!

I've opened this pull request here instead of scikit-fuzzy repo, because I've noticed you've got an open pull request for docs with many things improved already.

:heavy_check_mark: Got rid of these nasty errors:
`WARNING: error while formatting signature for ... 'autodoc-process-signature' threw an exception (exception: 'dict' object has no attribute 'has_key')`
by updating syntax appropriate for Python 3.x in _docs/ext/docscrape.py_

:heavy_check_mark: ...And it uncovered a new error:
`Extension error (numpydoc):
Handler <function mangle_docstrings at 0x7f3fffa64dc0> for event 'autodoc-process-docstring' threw an exception (exception: 'SphinxObjDoc' object has no attribute 'split')`
so I've dealt with this by explicitly converting the doc object to string before applying split() in _docs/ext/numpydoc.py_

 :heavy_check_mark: All links referring to the api page are now pointing to _/api/index.html_ - previously there were some _/api/api.html_ references left resulting in 404s

 :heavy_check_mark: Set up a ~~GitHub action~~ travis job to build docs on every push to master and publish to gh-pages